### PR TITLE
add support for token based credentials

### DIFF
--- a/src/Common/Auth/AccessToken.php
+++ b/src/Common/Auth/AccessToken.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AzureOss\Storage\Common\Auth;
+
+final class AccessToken
+{
+    public function __construct(
+        public readonly string $accessToken,
+        public readonly \DateTimeInterface $expiresOn,
+    ) {}
+}

--- a/src/Common/Auth/ClientSecretCredential.php
+++ b/src/Common/Auth/ClientSecretCredential.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AzureOss\Storage\Common\Auth;
+
+use DateTimeImmutable;
+use GuzzleHttp\Client;
+use GuzzleHttp\RequestOptions;
+
+/**
+ * @see https://learn.microsoft.com/en-us/rest/api/storageservices/authorize-with-azure-active-directory
+ */
+final class ClientSecretCredential implements TokenCredential
+{
+    public function __construct(
+        private readonly string $tenantId,
+        private readonly string $clientId,
+        private readonly string $clientSecret,
+    ) {}
+
+    public function getToken(): AccessToken
+    {
+        $client = new Client();
+
+        $response = $client->post("https://login.microsoftonline.com/{$this->tenantId}/oauth2/token", [
+            RequestOptions::HEADERS => [
+                'Content-Type' => 'application/x-www-form-urlencoded',
+            ],
+            RequestOptions::FORM_PARAMS => [
+                'grant_type' => 'client_credential',
+                'client_id' => $this->clientId,
+                'client_secret' => $this->clientSecret,
+                'resource' => 'https://storage.azure.com/',
+            ],
+        ]);
+
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        if (! is_array($data) ||
+            ! array_key_exists('access_token', $data) ||
+            ! is_string($data['access_token']) ||
+            ! array_key_exists('expires_on', $data) ||
+            ! is_numeric($data['expires_on'])
+        ) {
+            throw new \RuntimeException('Unexpected response from Azure');
+        }
+
+        return new AccessToken(
+            $data['access_token'],
+            (new DateTimeImmutable())->setTimestamp((int) $data['expires_on']),
+        );
+    }
+}

--- a/src/Common/Auth/ClientSecretCredential.php
+++ b/src/Common/Auth/ClientSecretCredential.php
@@ -28,7 +28,7 @@ final class ClientSecretCredential implements TokenCredential
                 'Content-Type' => 'application/x-www-form-urlencoded',
             ],
             RequestOptions::FORM_PARAMS => [
-                'grant_type' => 'client_credential',
+                'grant_type' => 'client_credentials',
                 'client_id' => $this->clientId,
                 'client_secret' => $this->clientSecret,
                 'resource' => 'https://storage.azure.com/',

--- a/src/Common/Auth/TokenCredential.php
+++ b/src/Common/Auth/TokenCredential.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AzureOss\Storage\Common\Auth;
+
+interface TokenCredential
+{
+    public function getToken(): AccessToken;
+}

--- a/src/Common/Middleware/AddEntraIdAuthorizationHeaderMiddleware.php
+++ b/src/Common/Middleware/AddEntraIdAuthorizationHeaderMiddleware.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AzureOss\Storage\Common\Middleware;
+
+use AzureOss\Storage\Common\Auth\AccessToken;
+use AzureOss\Storage\Common\Auth\TokenCredential;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * @internal
+ */
+final class AddEntraIdAuthorizationHeaderMiddleware
+{
+    private ?AccessToken $cachedAccessToken = null;
+
+    public function __construct(private readonly TokenCredential $tokenCredential) {}
+
+    public function __invoke(callable $handler): \Closure
+    {
+        return function (RequestInterface $request, array $options) use ($handler) {
+            if ($this->cachedAccessToken === null ||
+                $this->expiresInAMinute($this->cachedAccessToken)
+            ) {
+                $this->cachedAccessToken = $this->tokenCredential->getToken();
+            }
+
+            $request = $request->withHeader('Authorization', 'Bearer ' . $this->cachedAccessToken->accessToken);
+
+            return $handler($request, $options);
+        };
+    }
+
+    private function expiresInAMinute(AccessToken $accessToken): bool
+    {
+        return $accessToken->expiresOn < (new \DateTimeImmutable())->add(new \DateInterval('PT1M'));
+    }
+}

--- a/src/Common/Middleware/AddSharedKeyAuthorizationHeaderMiddleware.php
+++ b/src/Common/Middleware/AddSharedKeyAuthorizationHeaderMiddleware.php
@@ -11,7 +11,7 @@ use Psr\Http\Message\RequestInterface;
 /**
  * @internal
  */
-final class AddAuthorizationHeaderMiddleware
+final class AddSharedKeyAuthorizationHeaderMiddleware
 {
     private const INCLUDED_HEADERS = [
         'Content-Encoding',

--- a/tests/Blob/BlobFeatureTestCase.php
+++ b/tests/Blob/BlobFeatureTestCase.php
@@ -17,7 +17,7 @@ abstract class BlobFeatureTestCase extends TestCase
         $connectionString = getenv('AZURE_STORAGE_BLOB_TEST_CONNECTION_STRING');
 
         if (!is_string($connectionString)) {
-            throw new \Exception('Connection string not set!');
+            self::fail('Invalid connection string. Please set AZURE_STORAGE_BLOB_TEST_CONNECTION_STRING environment variable.');
         }
 
         $this->serviceClient = BlobServiceClient::fromConnectionString($connectionString);

--- a/tests/Blob/Feature/BlobContainerClientTest.php
+++ b/tests/Blob/Feature/BlobContainerClientTest.php
@@ -45,7 +45,7 @@ final class BlobContainerClientTest extends BlobFeatureTestCase
         $containerClient = $client->getContainerClient("testing");
         $blobClient = $containerClient->getBlobClient("some/file.txt");
 
-        self::assertEquals($blobClient->sharedKeyCredentials, $containerClient->sharedKeyCredentials);
+        self::assertEquals($blobClient->credential, $containerClient->credential);
         self::assertEquals("http://127.0.0.1:10000/devstoreaccount1/testing/some/file.txt", (string) $blobClient->uri);
     }
 
@@ -59,7 +59,7 @@ final class BlobContainerClientTest extends BlobFeatureTestCase
         $containerClient = $client->getContainerClient("testing");
         $blobClient = $containerClient->getBlobClient("/some/file.txt");
 
-        self::assertEquals($blobClient->sharedKeyCredentials, $containerClient->sharedKeyCredentials);
+        self::assertEquals($blobClient->credential, $containerClient->credential);
         self::assertEquals("http://127.0.0.1:10000/devstoreaccount1/testing/some/file.txt", (string) $blobClient->uri);
     }
 
@@ -359,13 +359,13 @@ final class BlobContainerClientTest extends BlobFeatureTestCase
     }
 
     #[Test]
-    public function generate_sas_uri_throws_when_there_are_no_shared_key_credentials(): void
+    public function generate_sas_uri_throws_when_there_are_no_shared_key_credential(): void
     {
         $this->expectException(UnableToGenerateSasException::class);
 
-        $containerClientWithoutCredentials = new BlobContainerClient(new Uri("example.com"));
+        $containerClientWithoutCredential = new BlobContainerClient(new Uri("example.com"));
 
-        $containerClientWithoutCredentials->generateSasUri(
+        $containerClientWithoutCredential->generateSasUri(
             BlobSasBuilder::new(),
         );
     }

--- a/tests/Blob/Feature/BlobServiceClientTest.php
+++ b/tests/Blob/Feature/BlobServiceClientTest.php
@@ -25,9 +25,9 @@ final class BlobServiceClientTest extends BlobFeatureTestCase
         $connectionString = "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;";
         $client = BlobServiceClient::fromConnectionString($connectionString);
 
-        self::assertNotNull($client->sharedKeyCredentials);
-        self::assertEquals('devstoreaccount1', $client->sharedKeyCredentials->accountName);
-        self::assertEquals('Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==', $client->sharedKeyCredentials->accountKey);
+        self::assertInstanceOf(StorageSharedKeyCredential::class, $client->credential);
+        self::assertEquals('devstoreaccount1', $client->credential->accountName);
+        self::assertEquals('Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==', $client->credential->accountKey);
         self::assertEquals("http://127.0.0.1:10000/devstoreaccount1/", (string) $client->uri);
     }
 
@@ -37,9 +37,9 @@ final class BlobServiceClientTest extends BlobFeatureTestCase
         $connectionString = "DefaultEndpointsProtocol=https;AccountName=testing;AccountKey=Y2hlZXNlMWNoZWVzZTEyY2hlZXNlMTIzCg==;EndpointSuffix=core.windows.net";
         $client = BlobServiceClient::fromConnectionString($connectionString);
 
-        self::assertNotNull($client->sharedKeyCredentials);
-        self::assertEquals('testing', $client->sharedKeyCredentials->accountName);
-        self::assertEquals('Y2hlZXNlMWNoZWVzZTEyY2hlZXNlMTIzCg==', $client->sharedKeyCredentials->accountKey);
+        self::assertInstanceOf(StorageSharedKeyCredential::class, $client->credential);
+        self::assertEquals('testing', $client->credential->accountName);
+        self::assertEquals('Y2hlZXNlMWNoZWVzZTEyY2hlZXNlMTIzCg==', $client->credential->accountKey);
         self::assertEquals("https://testing.blob.core.windows.net/", (string) $client->uri);
     }
 
@@ -49,9 +49,9 @@ final class BlobServiceClientTest extends BlobFeatureTestCase
         $connectionString = "UseDevelopmentStorage=true";
         $client = BlobServiceClient::fromConnectionString($connectionString);
 
-        self::assertNotNull($client->sharedKeyCredentials);
-        self::assertEquals('devstoreaccount1', $client->sharedKeyCredentials->accountName);
-        self::assertEquals('Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==', $client->sharedKeyCredentials->accountKey);
+        self::assertInstanceOf(StorageSharedKeyCredential::class, $client->credential);
+        self::assertEquals('devstoreaccount1', $client->credential->accountName);
+        self::assertEquals('Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==', $client->credential->accountKey);
         self::assertEquals("http://127.0.0.1:10000/devstoreaccount1/", (string) $client->uri);
     }
 
@@ -85,7 +85,7 @@ final class BlobServiceClientTest extends BlobFeatureTestCase
         $connectionString = "BlobEndpoint=https://storagesample.blob.core.windows.net;SharedAccessSignature=sv=2015-07-08&sig=iCvQmdZngZNW%2F4vw43j6%2BVz6fndHF5LI639QJba4r8o%3D&spr=https&st=2016-04-12T03%3A24%3A31Z&se=2016-04-13T03%3A29%3A31Z&srt=s&ss=bf&sp=rwl";
         $client = BlobServiceClient::fromConnectionString($connectionString);
 
-        self::assertNull($client->sharedKeyCredentials);
+        self::assertNull($client->credential);
         self::assertEquals("https://storagesample.blob.core.windows.net/?sv=2015-07-08&sig=iCvQmdZngZNW%2F4vw43j6%2BVz6fndHF5LI639QJba4r8o%3D&spr=https&st=2016-04-12T03%3A24%3A31Z&se=2016-04-13T03%3A29%3A31Z&srt=s&ss=bf&sp=rwl", (string) $client->uri);
     }
 
@@ -115,7 +115,7 @@ final class BlobServiceClientTest extends BlobFeatureTestCase
 
         $containerClient = $client->getContainerClient("testing");
 
-        self::assertEquals($client->sharedKeyCredentials, $containerClient->sharedKeyCredentials);
+        self::assertEquals($client->credential, $containerClient->credential);
         self::assertEquals("http://127.0.0.1:10000/devstoreaccount1/testing", (string) $containerClient->uri);
     }
 
@@ -195,13 +195,13 @@ final class BlobServiceClientTest extends BlobFeatureTestCase
     }
 
     #[Test]
-    public function generate_account_sas_throws_when_there_are_no_shared_key_credentials(): void
+    public function generate_account_sas_throws_when_there_are_no_shared_key_credential(): void
     {
         $this->expectException(UnableToGenerateSasException::class);
 
-        $serviceClientWithoutCredentials = new BlobServiceClient(new Uri("example.com"));
+        $serviceClientWithoutCredential = new BlobServiceClient(new Uri("example.com"));
 
-        $serviceClientWithoutCredentials->generateAccountSasUri(
+        $serviceClientWithoutCredential->generateAccountSasUri(
             AccountSasBuilder::new(),
         );
     }

--- a/tests/Common/Feature/ClientSecretCredentialTest.php
+++ b/tests/Common/Feature/ClientSecretCredentialTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AzureOss\Storage\Tests\Common\Feature;
+
+use AzureOss\Storage\Common\Auth\ClientSecretCredential;
+use AzureOss\Storage\Common\Middleware\ClientFactory;
+use GuzzleHttp\RequestOptions;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class ClientSecretCredentialTest extends TestCase
+{
+    #[Test]
+    public function get_token_works(): void
+    {
+        $tenantId = getenv('AZURE_STORAGE_BLOB_TENANT_ID');
+        $clientId = getenv('AZURE_STORAGE_BLOB_CLIENT_ID');
+        $clientSecret = getenv('AZURE_STORAGE_BLOB_CLIENT_SECRET');
+
+        if ($tenantId === false || $clientId === false || $clientSecret === false) {
+            self::markTestSkipped('Not all env variables have been set for this test');
+        }
+
+        $credential = new ClientSecretCredential($tenantId, $clientId, $clientSecret);
+
+        $token = $credential->getToken();
+
+        self::assertGreaterThan(0, strlen($token->accessToken));
+        self::assertGreaterThan((new \DateTimeImmutable())->getTimestamp(), $token->expiresOn->getTimestamp());
+    }
+
+    #[Test]
+    public function making_request_works(): void
+    {
+        $endpoint = getenv('AZURE_STORAGE_BLOB_ENDPOINT');
+        $tenantId = getenv('AZURE_STORAGE_BLOB_TENANT_ID');
+        $clientId = getenv('AZURE_STORAGE_BLOB_CLIENT_ID');
+        $clientSecret = getenv('AZURE_STORAGE_BLOB_CLIENT_SECRET');
+
+        if ($endpoint === false || $tenantId === false || $clientId === false || $clientSecret === false) {
+            self::markTestSkipped('Not all env variables have been set for this test');
+        }
+
+        $client = (new ClientFactory())->create(
+            credential: new ClientSecretCredential($tenantId, $clientId, $clientSecret),
+        );
+
+        $response = $client->get($endpoint . '/', [
+            RequestOptions::QUERY => [
+                'comp' => 'list',
+            ],
+        ]);
+
+        self::assertEquals(200, $response->getStatusCode());
+    }
+}

--- a/tests/Common/Feature/StorageSharedKeyCredentialTest.php
+++ b/tests/Common/Feature/StorageSharedKeyCredentialTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AzureOss\Storage\Tests\Common\Feature;
+
+use AzureOss\Storage\Common\Auth\StorageSharedKeyCredential;
+use AzureOss\Storage\Common\Helpers\ConnectionStringHelper;
+use AzureOss\Storage\Common\Middleware\ClientFactory;
+use GuzzleHttp\RequestOptions;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class StorageSharedKeyCredentialTest extends TestCase
+{
+    #[Test]
+    public function making_request_works(): void
+    {
+        $connectionString = getenv('AZURE_STORAGE_BLOB_TEST_CONNECTION_STRING');
+
+        if ($connectionString === false) {
+            self::fail('Invalid connection string. Please set AZURE_STORAGE_BLOB_TEST_CONNECTION_STRING environment variable.');
+        }
+
+        $endpoint = ConnectionStringHelper::getBlobEndpoint($connectionString);
+        $accountName = ConnectionStringHelper::getAccountName($connectionString);
+        $accountKey = ConnectionStringHelper::getAccountKey($connectionString);
+
+
+        if ($endpoint === null || $accountName === null || $accountKey === null) {
+            self::fail('Invalid connection string. Please set AZURE_STORAGE_BLOB_TEST_CONNECTION_STRING environment variable.');
+        }
+
+        $client = (new ClientFactory())->create(
+            credential: new StorageSharedKeyCredential($accountName, $accountKey),
+        );
+
+        $response = $client->get($endpoint . '/', [
+            RequestOptions::QUERY => [
+                'comp' => 'list',
+            ],
+        ]);
+
+        self::assertEquals(200, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
This should allow us to support many more auth methods in the future. You can add a new credential type by extending the TokenCredential interface.

For now I added one implementation: ClientSecretCredential