### PR TITLE
Add option to disable SSL verification for local Azurite support with self-signed certificates

### DIFF
--- a/src/Common/Middleware/HttpClientOptions.php
+++ b/src/Common/Middleware/HttpClientOptions.php
@@ -13,7 +13,7 @@ final class HttpClientOptions
     ) {}
 
     /**
-     * @return array{timeout?: int, connect_timeout?: int}
+     * @return array{timeout?: int, connect_timeout?: int, verify?: bool}
      */
     public function toGuzzleHttpClientConfig(): array
     {

--- a/src/Common/Middleware/HttpClientOptions.php
+++ b/src/Common/Middleware/HttpClientOptions.php
@@ -9,6 +9,7 @@ final class HttpClientOptions
     public function __construct(
         public readonly ?int $timeout = null,
         public readonly ?int $connectTimeout = null,
+        public readonly ?bool $verifySsl = null,
     ) {}
 
     /**
@@ -19,6 +20,7 @@ final class HttpClientOptions
         return array_filter([
             'timeout' => $this->timeout,
             'connect_timeout' => $this->connectTimeout,
+            'verify' => $this->verifySsl,
         ], fn($value) => $value !== null);
     }
 }


### PR DESCRIPTION
In order to use OAuth authentication with Azurite, [HTTPS is required](https://learn.microsoft.com/en-us/azure/storage/common/storage-install-azurite?tabs=visual-studio%2Cblob-storage#certificate-configuration-https). This PR adds an option to disable the certificate verification in Guzzle so that this package can be used with self-signed certificates for development.